### PR TITLE
Add auto `z-index` to `Modal` instances

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+  let counter = 0;
+</script>
+
 <script lang="ts">
   import { tick } from "svelte";
 
@@ -9,19 +13,21 @@
     show = false;
     tick().finally(cleanup);
   }
+
+  $: count = show ? ++counter : -1;
 </script>
 
 <slot name="backdrop" {close}>
   {#if closeOnClickOutside}
-    <div role="presentation" class="fixed inset-0 transition duration-1000" class:show class:pointer-events-none={!show} on:click={close} />
+    <div role="presentation" class="fixed inset-0 transition duration-1000" class:show style:z-index={count} class:pointer-events-none={!show} on:click={close} />
   {:else}
-    <div class="pointer-events-none fixed inset-0 transition duration-1000" class:show />
+    <div class="pointer-events-none fixed inset-0 transition duration-1000" class:show style:z-index={count} />
   {/if}
 </slot>
 
 {#if show}
   <slot {close}>
-    <div class="pointer-events-none fixed inset-0 grid place-items-center [&>*]:pointer-events-auto">
+    <div class="pointer-events-none fixed inset-0 grid place-items-center [&>*]:pointer-events-auto" style:z-index={count}>
       <slot name="content" {close} />
     </div>
   </slot>

--- a/src/routes/test/+page.svelte
+++ b/src/routes/test/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+  import Modal from "$lib/components/Modal.svelte";
+  import { onMount } from "svelte";
+
+  let show = false;
+
+  onMount(() => {
+    setTimeout(() => {
+      show = true;
+    }, 100);
+  });
+</script>
+
+<Modal {show}>
+  <div slot="content" class="h-30 w-70 bg-cyan" />
+</Modal>
+
+<Modal show>
+  <div slot="content" class="h-60 w-60 bg-red">
+</Modal>
+
+<div class="fixed bottom-20 self-center">the cyan square should be on top of the red one</div>


### PR DESCRIPTION
This pull request adds an auto `z-index` property to `Modal` instances. The `Modal` component now automatically assigns a `z-index` value to each instance, ensuring that the modal with the highest `z-index` value is displayed on top of other modals. This improves the visual stacking order of modals and prevents overlapping.