### PR TITLE
Add postinstall script to generate declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "build": "vite build --sourcemap",
     "preview": "vite preview",
+    "postinstall": "node src/lib/utils/generateDeclarations.js",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },

--- a/src/lib/utils/generateDeclarations.js
+++ b/src/lib/utils/generateDeclarations.js
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const srcPath = "./src";
+
+const files = readdirSync(srcPath, { recursive: true, withFileTypes: true }).filter(file => file.isFile()).map(({ parentPath, name }) => `${parentPath}/${name}`);
+
+for (const file of files) {
+  if (!file.endsWith(".ts") && !file.endsWith(".svelte"))
+    continue;
+
+  const content = readFileSync(file, "utf-8");
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const importMatch = line.match(/import\s.*from\s*["'](.+)["']/);
+    if (importMatch) {
+      const modulePath = resolve(file, "..", importMatch[1]);
+
+      if (existsSync(modulePath) && statSync(modulePath).isDirectory() && !existsSync(join(modulePath, "index.ts"))) {
+        // generate dts
+        writeFileSync(join(modulePath, "index.d.ts"), `export default {} as {${readdirSync(modulePath).map(name => `\n  ${JSON.stringify(name)}: string;`).join("")}\n}`, "utf-8");
+        console.warn(`Generated ${modulePath}/index.d.ts`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a postinstall script that scans the source directory for TypeScript and Svelte files, identifies module imports, and generates index.d.ts files for modules that lack an index.ts file.

New Features:
- Add a postinstall script to generate TypeScript declaration files for modules without an index.ts file.

<!-- Generated by sourcery-ai[bot]: end summary -->