### PR TITLE
Untitled

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,6 +10,9 @@ const config = {
     alias: {
       "$py/*": "src/python/*",
     },
+    output: {
+      preloadStrategy: "preload-mjs",
+    },
   },
 };
 


### PR DESCRIPTION
chore: update SvelteKit config to include `preloadStrategy: "preload-mjs"`

## Summary by Sourcery

Chores:
- Set `preloadStrategy` to `preload-mjs` in the SvelteKit config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Optimized module preloading, potentially enhancing application load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->