### PR TITLE
Only use frame transversing to get `current_computations`

### DIFF
--- a/packages/hmr/reactivity/hmr/fs.py
+++ b/packages/hmr/reactivity/hmr/fs.py
@@ -14,14 +14,12 @@ def fs_signals():
 
 @cache
 def setup_fs_audithook():
-    current_computations = HMR_CONTEXT.current_computations
-
     @sys.addaudithook
     def _(event: str, args: tuple):
         if event == "open":
             file, _, flags = args
 
-            if (flags % 2 == 0) and current_computations and isinstance(file, str):
+            if (flags % 2 == 0) and HMR_CONTEXT.current_computations and isinstance(file, str):
                 track(file)
 
 


### PR DESCRIPTION
- #369 Attempt 2 (code is generated with AI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved computation tracking by dynamically inspecting the call stack, removing explicit stack management.
  * Updated context management to use implicit state for computations and untracking.
  * Streamlined context creation and callback scheduling for better reliability.

* **Style**
  * Simplified references to current computations for more consistent state access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->