### PR TITLE
Cache pyodide assets and wheels

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -92,12 +92,34 @@ sw.addEventListener("fetch", (event) => {
     const url = new URL(event.request.url);
     const cache = await caches.open(CACHE);
 
-    // immutable assets always be served from the cache
-    if (allAssets.includes(url.pathname) || String(url).startsWith(indexURL)) {
-      const response = await cache.match(event.request);
+    // Helper: identify pyodide-related requests (runtime assets, CDN content, wheels)
+    const isPyodideRequest = (() => {
+      // direct pyodide runtime files
+      if (allAssets.includes(url.pathname)) return true;
+      // anything under the pyodide CDN/base index
+      if (String(url).startsWith(indexURL)) return true;
+      // wheel requests, including via proxy
+      if (url.pathname.endsWith(".whl")) return true;
+      const proxied = url.searchParams.get("url");
+      if (proxied && /\.whl($|\?)/.test(proxied)) return true;
+      return false;
+    })();
 
-      if (response) {
-        return response;
+    // For all pyodide assets and wheels: cache-first, then network, then cache the result
+    if (isPyodideRequest) {
+      const cached = await cache.match(event.request);
+      if (cached) return cached;
+      try {
+        const networkResponse = await fetchWithProxy(event.request.clone());
+        if (networkResponse instanceof Response && networkResponse.status === 200) {
+          cache.put(event.request, networkResponse.clone());
+        }
+        return networkResponse;
+      }
+      catch (err) {
+        const fallback = await cache.match(event.request);
+        if (fallback) return fallback;
+        throw err;
       }
     }
 


### PR DESCRIPTION
Implement a cache-first strategy in the service worker for all Pyodide assets and wheels.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2fa8f96-cf13-4732-9f74-911a6db7b8cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2fa8f96-cf13-4732-9f74-911a6db7b8cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

