### PR TITLE
Refactor HMR MCP endpoint to fetch prerendered payloads

### DIFF
--- a/src/routes/hmr/mcp/+server.ts
+++ b/src/routes/hmr/mcp/+server.ts
@@ -1,31 +1,12 @@
 import type { RequestHandler } from "./$types";
 import type { JSONSchema7 } from "json-schema";
 
-import coreFiles from "../../../../packages/hmr";
-import testFiles from "../../../../tests/py";
-import concepts from "../concepts";
 import { HttpTransport } from "@tmcp/transport-http";
-import { packXML } from "$lib/utils/pack";
 import { McpServer } from "tmcp";
-
-const docs = `\
-# Hot Module Reload for Python (https://pypi.org/project/hmr/)
-
-${coreFiles["README.md"].replace(/.*<\/div>/s, "").trim()}
-
----
-
-${concepts}
-
----
-
-The \`hmr\` library doesn't have a documentation site yet, but the code is high-quality and self-explanatory.
-Now you should read the source code (using the other two MCP tools) for more information on how to use it.
-`;
 
 const entrypoints = [
   {
-    content: docs,
+    key: "about",
     uri: "hmr-docs://about",
     tool: "learn-hmr-basics",
     title: "About HMR",
@@ -37,7 +18,7 @@ const entrypoints = [
     ].join(" "),
   },
   {
-    content: `# Files under <https://github.com/promplate/pyth-on-line/packages/hmr>:\n\n${packXML(coreFiles)}`,
+    key: "core-files",
     uri: "hmr-docs://core-files",
     tool: "view-hmr-core-sources",
     title: "HMR Sources",
@@ -51,7 +32,7 @@ const entrypoints = [
     ].join(" "),
   },
   {
-    content: `# Files under <https://github.com/promplate/pyth-on-line/tests/py>:\n\n${packXML(testFiles)}`,
+    key: "test-files",
     uri: "hmr-docs://test-files",
     tool: "view-hmr-unit-tests",
     title: "HMR Unit Tests",
@@ -63,48 +44,69 @@ const entrypoints = [
       "The response is identical to the MCP resource with the same name. Only use it once and prefer this tool to that resource if you can choose.",
     ].join(" "),
   },
-];
+] as const;
 
 // a minimal icon using python's color scheme
 const icons = [{ mimeType: "image/webp", src: "data:image/webp;base64,UklGRkoAAABXRUJQVlA4TD0AAAAvj8AjEBcgEEjypxlnNAVpGzDd8694IBBIktp22PkP8NsGQg0MJZWU86YAj4j+T4B+ceplERrXhF1vygEGAA==" }];
 
-const server = new McpServer(
-  {
-    name: "hmr-docs",
-    version: "1.0.0",
-    description: "Docs for the HMR library for Python (python modules `reactivity` and `reactivity.hmr`).",
-    websiteUrl: "https://github.com/promplate/hmr",
-    icons,
-  },
-  {
-    adapter: {
-      async toJsonSchema() {
-        return {} as JSONSchema7; // minimal adapter since we don't use any schemas
-      },
-    },
-    capabilities: {
-      tools: {},
-      prompts: {},
-      resources: {},
-    },
-  },
-);
+async function loadContents(fetch: typeof globalThis.fetch, origin: string) {
+  const requests = entrypoints.map(async ({ key }) => {
+    const response = await fetch(`${origin}/hmr/mcp/content/${key}`);
 
-for (const { content, uri, tool, title, description, hint } of entrypoints) {
-  const resource = { text: content, uri };
-  server.tool({ name: tool, title: tool, description: `${description}\n\n${hint}`, annotations: { readOnlyHint: true }, icons }, () => ({ content: [{ type: "resource", resource }] }));
-  server.resource({ name: title, title, description, uri, icons }, () => ({ contents: [resource] }));
-  server.prompt({ name: tool, description, icons }, () => ({ description, messages: [{ role: "user", content: { type: "resource", resource } }] }));
+    if (!response.ok) {
+      throw new Error(`Failed to fetch prerendered MCP payload: ${key}`);
+    }
+
+    const { content } = (await response.json()) as { content: string };
+    return [key, content] as const;
+  });
+
+  return Object.fromEntries(await Promise.all(requests));
 }
 
-const transport = new HttpTransport(server, {
-  path: "/hmr/mcp",
-  cors: true,
-  disableSse: true,
-});
+function createTransport(contents: Record<string, string>) {
+  const server = new McpServer(
+    {
+      name: "hmr-docs",
+      version: "1.0.0",
+      description: "Docs for the HMR library for Python (python modules `reactivity` and `reactivity.hmr`).",
+      websiteUrl: "https://github.com/promplate/hmr",
+      icons,
+    },
+    {
+      adapter: {
+        async toJsonSchema() {
+          return {} as JSONSchema7; // minimal adapter since we don't use any schemas
+        },
+      },
+      capabilities: {
+        tools: {},
+        prompts: {},
+        resources: {},
+      },
+    },
+  );
 
-const handler: RequestHandler = async ({ request }) => {
+  for (const { key, uri, tool, title, description, hint } of entrypoints) {
+    const resource = { text: contents[key], uri };
+    server.tool({ name: tool, title: tool, description: `${description}\n\n${hint}`, annotations: { readOnlyHint: true }, icons }, () => ({ content: [{ type: "resource", resource }] }));
+    server.resource({ name: title, title, description, uri, icons }, () => ({ contents: [resource] }));
+    server.prompt({ name: tool, description, icons }, () => ({ description, messages: [{ role: "user", content: { type: "resource", resource } }] }));
+  }
+
+  return new HttpTransport(server, {
+    path: "/hmr/mcp",
+    cors: true,
+    disableSse: true,
+  });
+}
+
+const handler: RequestHandler = async ({ request, fetch, url }) => {
+  const origin = url.origin || new URL(request.url).origin;
+  const contents = await loadContents(fetch, origin);
+  const transport = createTransport(contents);
   const response = await transport.respond(request);
+
   return response ?? new Response("Not Found", { status: 404 });
 };
 

--- a/src/routes/hmr/mcp/content/[kind]/+server.ts
+++ b/src/routes/hmr/mcp/content/[kind]/+server.ts
@@ -1,0 +1,44 @@
+import type { EntryGenerator, RequestHandler } from "./$types";
+
+import coreFiles from "../../../../../packages/hmr";
+import testFiles from "../../../../../tests/py";
+import concepts from "../../../concepts";
+import { json } from "@sveltejs/kit";
+import { packXML } from "$lib/utils/pack";
+
+const docs = `\
+# Hot Module Reload for Python (https://pypi.org/project/hmr/)
+
+${coreFiles["README.md"].replace(/.*<\/div>/s, "").trim()}
+
+---
+
+${concepts}
+
+---
+
+The \`hmr\` library doesn't have a documentation site yet, but the code is high-quality and self-explanatory.
+Now you should read the source code (using the other two MCP tools) for more information on how to use it.
+`;
+
+const contents = {
+  "about": docs,
+  "core-files": `# Files under <https://github.com/promplate/pyth-on-line/packages/hmr>:\n\n${packXML(coreFiles)}`,
+  "test-files": `# Files under <https://github.com/promplate/pyth-on-line/tests/py>:\n\n${packXML(testFiles)}`,
+} as const;
+
+export const GET: RequestHandler = ({ params: { kind } }) => {
+  const content = contents[kind as keyof typeof contents];
+
+  if (!content) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  return json({ content });
+};
+
+export const prerender = true;
+
+export const entries: EntryGenerator = () => {
+  return Object.keys(contents).map(kind => ({ kind }));
+};


### PR DESCRIPTION
### Motivation
- Reduce the Edge runtime bundle by avoiding heavy static imports in the handler and instead fetch static payloads at runtime.  
- Keep statically-rendered content prerendered (so docs remain static) while making the Edge handler lightweight enough for Vercel Edge limits.  
- Support all MCP content variants (about / core-files / test-files) as separately prerendered payloads so the MCP server can register tools/resources from fetched data.

### Description
- Modified `src/routes/hmr/mcp/+server.ts` to no longer import `packages/hmr`, `tests/py`, or `concepts`, and instead fetch prerendered content from the site at request time via `loadContents()` and `createTransport()`; the handler now builds the `McpServer` from the fetched payloads.  
- Added `src/routes/hmr/mcp/content/[kind]/+server.ts` which statically generates the three content variants (`about`, `core-files`, `test-files`) and exposes them as JSON; this route uses `export const prerender = true` and an `entries` generator so those payloads are prerendered.  
- Kept MCP tools/resources/prompts metadata unchanged and only switched the content source from inline imports to fetched prerendered payloads to minimize diff size and runtime footprint.

### Testing
- Ran linting on the modified files with `pnpm -s eslint src/routes/hmr/mcp/+server.ts src/routes/hmr/mcp/content/[kind]/+server.ts`, which completed successfully.  
- Ran type/diagnostic check with `pnpm -s check`, which surfaced existing unrelated missing-module type errors in other parts of the repository and did not introduce new route-specific diagnostics.  
- Verified the new `content/[kind]` route exposes `about`, `core-files`, and `test-files` and that the edge handler fetches those endpoints and registers MCP resources (manual runtime verification during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b1168d429483238a55273b16eadc80)