### PR TITLE
Reduce Shiki SSR bundle pressure by dropping bundledLanguages import

### DIFF
--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -1,17 +1,21 @@
 import type { ShikiTransformer } from "shiki";
 
 import { cacheGlobally } from "./utils/cache";
-import { bundledLanguages, createHighlighter } from "shiki";
-
-export const languages = Object.keys(bundledLanguages);
+import { createHighlighter } from "shiki";
 
 export async function getHighlighter(lang: string) {
-  if (!languages.includes(lang) && lang !== "text") {
-    console.error(`Language "${lang}" is not supported by Shiki.`);
-    lang = "text";
-  }
   return await cacheGlobally(`shiki-${lang}`, async () => {
-    return await createHighlighter({ themes: ["vitesse-dark"], langs: [lang] });
+    try {
+      return await createHighlighter({ themes: ["vitesse-dark"], langs: [lang] });
+    }
+    catch {
+      // `bundledLanguages` eagerly pulls every grammar into SSR bundles.
+      if (lang !== "text") {
+        console.error(`Language "${lang}" is not supported by Shiki.`);
+        return await createHighlighter({ themes: ["vitesse-dark"], langs: ["text"] });
+      }
+      throw new Error("Failed to initialize Shiki highlighter.");
+    }
   })();
 }
 


### PR DESCRIPTION
### Motivation
- The eager `bundledLanguages` import from `shiki` pulls many language grammars into SSR bundles, which greatly increases server/Edge bundle size and is a likely cause of Vercel Edge function size overages.

### Description
- Remove the `bundledLanguages` import in `src/lib/highlight.ts` and add a runtime `createHighlighter` try/catch that falls back to the `text` highlighter and logs when a language initialization fails, preserving behavior while avoiding the eager language registry.

### Testing
- Ran `bun run check` (svelte-check) which completed with 0 errors, and used `esbuild` to bundle server entries to produce and inspect artifact sizes; the build/bundle commands executed successfully for analysis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b11b5e6fe48323a70ae5c20c0b53be)