### PR TITLE
fix: propagate dirty state between deriveds

### DIFF
--- a/packages/hmr/reactivity/primitives.py
+++ b/packages/hmr/reactivity/primitives.py
@@ -43,10 +43,6 @@ class Subscribable:
     def notify(self):
         ctx = self.context.leaf
 
-        if isinstance(self, Derived):
-            for sub in self.subscribers:
-                if isinstance(sub, Derived):
-                    sub.dirty = True
         if ctx.batches:
             ctx.schedule_callbacks(self.subscribers)
         else:
@@ -297,6 +293,13 @@ class Derived[T](BaseDerived[T]):
             else:
                 self._value = value
                 self.notify()
+
+    def notify(self):
+        # HMR uses BaseDerived hybrid nodes with different scheduling semantics.
+        for sub in self.subscribers:
+            if isinstance(sub, Derived):
+                sub.dirty = True
+        super().notify()
 
     def __call__(self):
         self.track()

--- a/packages/hmr/reactivity/primitives.py
+++ b/packages/hmr/reactivity/primitives.py
@@ -43,6 +43,10 @@ class Subscribable:
     def notify(self):
         ctx = self.context.leaf
 
+        if isinstance(self, Derived):
+            for sub in self.subscribers:
+                if isinstance(sub, Derived):
+                    sub.dirty = True
         if ctx.batches:
             ctx.schedule_callbacks(self.subscribers)
         else:
@@ -228,7 +232,6 @@ class Batch:
             deriveds: list[BaseDerived] = []
             for computation in self.callbacks - triggered:
                 if isinstance(computation, BaseDerived):
-                    computation.dirty = True  # to prevent a dirty Derived from being missed by a subscriber's _sync_dirty_deps before marking
                     deriveds.append(computation)
                 else:
                     callbacks.append(computation)
@@ -236,12 +239,9 @@ class Batch:
             for d in deriveds:
                 d.trigger()
                 triggered.add(d)
-            # Deriveds are triggered first to ensure intermediate nodes in the dependency graph are updated before callbacks execute.
-            # This prevents stale values when callbacks read from derived computations.
-            # TODO: Extend this ordering to handle `Memoized` and other nodes that inherit from both Subscribable and BaseComputation.
             for computation in callbacks:
                 if computation in self.callbacks:
-                    continue  # skip if re-added during callback
+                    continue
                 computation.trigger()
                 triggered.add(computation)
 


### PR DESCRIPTION
## Summary

This fixes stale derived values in push-pull reactivity when an outer `Derived` indirectly reads a chain of derived properties.

The failing shape was:

```py
s -> d1 -> d2 -> d3 -> d4
d5 = lambda: (s, d1, d2, d3, d4)
effect(lambda: print(*d5()))
```

After `s` changed, the system could print a partially updated snapshot such as:

```text
2 2 1 1 1
```

instead of:

```text
2 2 2 2 2
```

## Root cause

The runtime already tried to avoid stale reads by triggering derived computations before effects in `Batch.flush()`. However, the important dirty mark for downstream derived computations happened too late: it happened while consuming the batch queue.

When `d1` recomputed and called `notify()`, `d2` was scheduled, but `d2.dirty` was not set immediately. Because the batch queue is a set and the graph can contain both the downstream derived chain and a hard puller (`d5` through the effect), `d5` could be pulled before `d2`, `d3`, and `d4` were marked dirty. At that point, pull-time dependency syncing saw `d1` as fresh but still considered the rest of the chain clean, producing a mixed old/new value.

In other words, the bug was not that pull-time recomputation was missing. The bug was that the dirty information had not reached the derived edge before another puller observed the graph.

## Fix

Move the downstream dirty mark to the moment a `Derived` actually notifies derived subscribers:

```py
if isinstance(self, Derived):
    for sub in self.subscribers:
        if isinstance(sub, Derived):
            sub.dirty = True
```

This makes the derived-to-derived edge update atomic from the perspective of later pullers: if a derived value changed and it is notifying downstream derived nodes, those downstream nodes are already marked dirty before any queued hard puller can observe them.

`Batch.flush()` then no longer needs to patch `dirty` while consuming derived callbacks; it can stay focused on scheduling.

## Why this keeps the push-pull model

This does not eagerly recompute the whole derived chain. It only propagates the fact that a downstream derived may now be stale. Actual recomputation still happens on pull via `Derived.__call__()` and `_sync_dirty_deps()`.

So the responsibilities remain:

- push: propagate invalidation / dirty state across derived-to-derived edges
- pull: recompute only the values that are actually read
- equality check: still gate downstream notification because `Derived.notify()` is called only after `recompute()` determines the value changed

This preserves the minimal-computation behavior: unrelated deriveds stay lazy, repeated reads reuse the cache, and unchanged derived values do not notify downstream hard pullers.

## HMR consideration

A broader version of this change that marked all `BaseDerived` subscribers dirty from `Subscribable.notify()` caused HMR regressions: `Name(Signal, BaseDerived)` and module reload derived nodes rely on more specific scheduling semantics and could be retriggered or skipped in the wrong order.

The final change is intentionally narrower: it only marks downstream subscribers when the notifying node itself is a normal `Derived`, and only marks downstream normal `Derived` subscribers. That fixes the stale derived chain while leaving HMR's special `Signal + BaseDerived` nodes alone.

## Test plan

```text
uv run pytest tests/py/test_reactivity.py tests/py/test_hmr.py -q
71 passed, 1 xfailed

uv run pytest -q
104 passed, 2 xfailed
```