### PR TITLE
feat(hmr): add real vLLM CPU HMR example

### DIFF
--- a/examples/vllm-cpu-hmr/Dockerfile
+++ b/examples/vllm-cpu-hmr/Dockerfile
@@ -1,0 +1,20 @@
+FROM vllm/vllm-openai-cpu:v0.28.0-x86_64
+
+USER root
+WORKDIR /opt/vllm-hmr
+
+# Install the HMR package from this checkout, not from an unpinned wheel.
+COPY packages/hmr /opt/hmr-source
+RUN /opt/venv/bin/pip install --no-deps /opt/hmr-source
+
+# Copy the example so the container is self-contained.
+COPY examples/vllm-cpu-hmr /opt/vllm-hmr
+RUN /opt/venv/bin/pip install --no-deps /opt/vllm-hmr
+
+# pyth-on-line excludes virtualenv/site-packages paths. Keep the official
+# release bytes, but expose them from an external source root for this probe.
+RUN mkdir -p /opt/vllm-release-source \
+    && cp -a /opt/venv/lib/python3.12/site-packages/vllm /opt/vllm-release-source/
+
+ENV PYTHONPATH=/opt/vllm-hmr:/opt/vllm-release-source
+ENTRYPOINT ["python3", "/opt/vllm-hmr/smoke.py"]

--- a/examples/vllm-cpu-hmr/README.md
+++ b/examples/vllm-cpu-hmr/README.md
@@ -1,0 +1,73 @@
+# Real vLLM CPU HMR example
+
+This example demonstrates a narrow, disposable HMR boundary in a real vLLM
+OpenAI-compatible server. It is not a claim that arbitrary vLLM modules,
+compiled kernels, CUDA Graphs, or model weights are safe to replace in place.
+
+## Run
+
+From the repository root:
+
+```bash
+docker pull vllm/vllm-openai-cpu:v0.28.0-x86_64
+./examples/vllm-cpu-hmr/run.sh
+```
+
+The script builds a local image from the official vLLM CPU image, installs the
+`hmr` package from this checkout, starts one real vLLM server, and writes:
+
+```text
+vllm-cpu-hmr-results/cpu-smoke-receipt.json
+vllm-cpu-hmr-results/cpu-smoke-full.log
+```
+
+Set `VLLM_HMR_MODEL` to use another compatible small model and
+`VLLM_HMR_RESULTS` to choose another output directory. The default model is
+`facebook/opt-125m` so the smoke is practical on a CPU-only machine.
+
+## What the smoke proves
+
+The runner performs exactly this sequence:
+
+1. Start the official `vllm/vllm-openai-cpu:v0.28.0-x86_64` image.
+2. Complete one real `POST /v1/completions` request.
+3. Insert one unique `print` into the existing vLLM function
+   `vllm/renderers/inputs/preprocess.py:extract_prompt_components`.
+4. Wait for the manifest watcher to observe that file.
+5. Publish the candidate at the next request boundary. The direct
+   `from vllm.renderers.inputs.preprocess import extract_prompt_components`
+   consumer is explicitly invalidated and re-executed.
+6. Complete the next real OpenAI API request without restarting the server.
+7. Require the marker in the API process log, unchanged API/worker PIDs,
+   unchanged model object/class/parameter pointers, no model-load evidence,
+   and HTTP 200.
+8. Restore the edited file byte-for-byte and remove the container.
+
+The manifest and receipt make the source layout explicit. The official CPU
+image installs vLLM under `site-packages`; the Dockerfile copies that package
+byte-for-byte to an external source root because pyth-on-line intentionally
+excludes virtualenv/site-packages paths from reactive wrapping.
+
+The HMR watcher is injected by `sitecustomize.py` before vLLM imports. The
+short-lived vLLM model-registry inspection helper is excluded from watcher
+installation because it runs during architecture inspection and must not
+inherit a native watch thread. The API and model worker processes still prove
+that the HMR injection and manifest are active.
+
+## Scope and limits
+
+This is an example and validation boundary, not a production deployment
+recipe. It covers one CPU/Python request path with one worker. It does not
+prove safety for:
+
+- arbitrary vLLM source files;
+- scheduler or lifecycle modules;
+- model class replacement;
+- weight reloads;
+- Triton/CUDA kernels;
+- `torch.compile` or CUDA Graphs;
+- multi-rank atomic publication;
+- long-lived production processes.
+
+Keep the lock in `run.sh` when running this alongside another engine's CPU
+experiment. The generated results are intentionally not committed.

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/__init__.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/__init__.py
@@ -1,0 +1,3 @@
+"""Disposable vLLM HMR observability package."""
+
+__all__ = []

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
@@ -1,6 +1,6 @@
 """Ambient pyth-on-line finder, watcher, and request-boundary publisher."""
 # This disposable integration deliberately reports candidate errors verbatim.
-# ruff: noqa: TRY003,TRY301,BLE001,S102,PLR0402
+# ruff: noqa: TRY003, TRY301
 # pyright: reportMissingImports=false, reportArgumentType=false, reportIndexIssue=false
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
@@ -1,0 +1,255 @@
+"""Ambient pyth-on-line finder, watcher, and request-boundary publisher."""
+# This disposable integration deliberately reports candidate errors verbatim.
+# ruff: noqa: TRY003,TRY301,BLE001,S102,PLR0402
+# pyright: reportMissingImports=false, reportArgumentType=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from . import telemetry
+from .policy import classify, matches_any, syntax_preflight
+
+_INSTALL_LOCK = threading.Lock()
+_INSTALLED = False
+_STATE_LOCK = threading.RLock()
+_SYNC_LOCK = threading.RLock()
+_PENDING: dict[Path, dict[str, Any]] = {}
+_FINDER = None
+_SOURCE_ROOT: Path | None = None
+_AUTO_PATTERNS: list[str] = []
+_LAZY_PATTERNS: list[str] = []
+_FORCED_DEPENDENTS: dict[str, list[str]] = {}
+_MANIFEST: dict[str, Any] | None = None
+_MANIFEST_PATHS: set[str] = set()
+_WATCH_STOP = threading.Event()
+_WATCH_THREAD: threading.Thread | None = None
+
+
+def _relative(path: Path) -> str:
+    assert _SOURCE_ROOT is not None
+    try:
+        return path.resolve().relative_to(_SOURCE_ROOT).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+def _stop_watcher() -> None:
+    _WATCH_STOP.set()
+    thread = _WATCH_THREAD
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=5)
+
+
+def install_from_env() -> None:
+    global _INSTALLED, _FINDER, _SOURCE_ROOT, _AUTO_PATTERNS, _LAZY_PATTERNS, _FORCED_DEPENDENTS
+    global _MANIFEST, _MANIFEST_PATHS, _WATCH_THREAD
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return
+        _SOURCE_ROOT = Path(os.environ["HMR_VLLM_SOURCE_ROOT"]).resolve()
+        _AUTO_PATTERNS = [p for p in os.getenv("HMR_VLLM_AUTO_PATTERNS", "").split(",") if p]
+        _LAZY_PATTERNS = [p for p in os.getenv("HMR_VLLM_LAZY_PATTERNS", "").split(",") if p]
+        _FORCED_DEPENDENTS = json.loads(os.getenv("HMR_VLLM_FORCED_DEPENDENTS", "{}"))
+
+        manifest_path = os.getenv("HMR_VLLM_MANIFEST")
+        if manifest_path:
+            manifest = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+            manifest_root = Path(manifest["source_root"]).resolve()
+            if manifest_root != _SOURCE_ROOT:
+                raise RuntimeError(f"manifest source_root {manifest_root} != configured source root {_SOURCE_ROOT}")
+            _MANIFEST_PATHS = {item["path"] for item in manifest["files"]}
+            for item in manifest["files"]:
+                path = _SOURCE_ROOT / item["path"]
+                digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                if digest != item["sha256"]:
+                    raise RuntimeError(f"manifest hash mismatch for {item['path']}: {digest} != {item['sha256']}")
+            _MANIFEST = manifest
+
+        reactive_relatives = list(_MANIFEST.get("reactive_paths", [])) if _MANIFEST else []
+        include_paths = [str((_SOURCE_ROOT / relative).resolve()) for relative in reactive_relatives] if reactive_relatives else [str(_SOURCE_ROOT / "vllm")]
+
+        from reactivity.hmr.core import patch_meta_path
+
+        _FINDER = patch_meta_path(includes=include_paths)
+        telemetry.install_profiler()
+        telemetry.event(
+            "hmr_installed",
+            includes=include_paths,
+            auto_patterns=_AUTO_PATTERNS,
+            lazy_patterns=_LAZY_PATTERNS,
+            manifest_path=manifest_path,
+            manifest_paths=sorted(_MANIFEST_PATHS),
+        )
+        _WATCH_THREAD = threading.Thread(target=_watch, name="hmr-vllm-watch", daemon=True)
+        _WATCH_THREAD.start()
+        atexit.register(_stop_watcher)
+        _INSTALLED = True
+
+
+def _watch() -> None:
+    from watchfiles import Change, watch
+
+    assert _SOURCE_ROOT is not None
+    try:
+        watch_paths = [str(_SOURCE_ROOT / relative) for relative in sorted(_MANIFEST_PATHS)] if _MANIFEST_PATHS else [str(_SOURCE_ROOT)]
+        for changes in watch(
+            *watch_paths,
+            debounce=int(os.getenv("HMR_VLLM_DEBOUNCE_MS", "300")),
+            step=50,
+            stop_event=_WATCH_STOP,
+        ):
+            now = time.monotonic()
+            with _STATE_LOCK:
+                for change, raw in changes:
+                    if change is Change.deleted:
+                        continue
+                    path = Path(raw).resolve()
+                    rel = _relative(path)
+                    if _MANIFEST_PATHS and rel not in _MANIFEST_PATHS:
+                        continue
+                    decision = classify(rel)
+                    _PENDING[path] = {
+                        "path": rel,
+                        "seen_at": now,
+                        "decision": decision.as_dict(),
+                    }
+                    telemetry.event("source_change", path=rel, decision=decision.as_dict())
+            _dump_status()
+    except BaseException as exc:
+        telemetry.event("watcher_failed", error=f"{type(exc).__name__}: {exc}")
+        _dump_status()
+
+
+def _load_handle(module):
+    """Access the intentionally private loader from a core-owned frame."""
+    import reactivity.hmr.core as core
+
+    helper = getattr(core, "_hmr_probe_load", None)
+    if helper is None:
+        namespace = core.__dict__
+        exec("def _hmr_probe_load(module):\n    return module.load\n", namespace)
+        helper = namespace["_hmr_probe_load"]
+    return helper(module)
+
+
+def _module_name(module) -> str:
+    return object.__getattribute__(module, "__name__")
+
+
+def sync_pending(*, force: bool = False) -> dict[str, Any]:
+    """Publish queued files at a request boundary; never called by the watcher."""
+    if not _INSTALLED:
+        return {"installed": False, "published": [], "rejected": []}
+    if telemetry.active_scopes() and not force:
+        telemetry.event("publication_deferred", reason="active_http_scopes")
+        return {"installed": True, "deferred": True, "published": [], "rejected": []}
+
+    from reactivity.hmr.core import HMR_CONTEXT, get_path_module_map
+    from reactivity.hmr.fs import notify
+    from reactivity.hmr.hooks import call_post_reload_hooks, call_pre_reload_hooks
+
+    published: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    with _SYNC_LOCK:
+        with _STATE_LOCK:
+            items = list(_PENDING.items())
+            _PENDING.clear()
+        if not items:
+            return {"installed": True, "deferred": False, "published": [], "rejected": []}
+
+        path_map = get_path_module_map()
+        by_name = {_module_name(module): module for module in path_map.values()}
+        call_pre_reload_hooks()
+        try:
+            with HMR_CONTEXT.batch():
+                for path, record in items:
+                    rel = record["path"]
+                    allowed = force or matches_any(rel, _AUTO_PATTERNS) or matches_any(rel, _LAZY_PATTERNS)
+                    if not allowed:
+                        rejected.append({**record, "error": "not allowlisted for automatic publication"})
+                        continue
+                    if path.suffix == ".py":
+                        ok, error = syntax_preflight(path)
+                        if not ok:
+                            rejected.append({**record, "error": error, "rollback": "old namespace not executed"})
+                            continue
+                    module = path_map.get(path.resolve())
+                    if module is None:
+                        notify(path.resolve())
+                        published.append({**record, "mode": "resource_notification_or_not_loaded"})
+                        continue
+                    load = _load_handle(module)
+                    load.invalidate()
+                    if matches_any(rel, _LAZY_PATTERNS):
+                        published.append({**record, "mode": "invalidated_for_late_read"})
+                        continue
+                    try:
+                        load()
+                        dirty_dependents = sorted(_module_name(candidate) for candidate in path_map.values() if getattr(_load_handle(candidate), "dirty", False))
+                        telemetry.event(
+                            "dependency_dirty_set",
+                            source=rel,
+                            modules=dirty_dependents,
+                        )
+                        forced_dependents_reexecuted = []
+                        for name in _FORCED_DEPENDENTS.get(rel, []):
+                            dependent = by_name.get(name)
+                            if dependent is None:
+                                raise RuntimeError(f"forced dependent {name!r} is not loaded")
+                            dependent_load = _load_handle(dependent)
+                            dependent_load.invalidate()
+                            dependent_load()
+                            forced_dependents_reexecuted.append(name)
+                        published.append(
+                            {
+                                **record,
+                                "mode": "eager_request_boundary",
+                                "dirty_dependents": dirty_dependents,
+                                "forced_dependents_reexecuted": forced_dependents_reexecuted,
+                            }
+                        )
+                    except BaseException as exc:
+                        rejected.append(
+                            {
+                                **record,
+                                "error": f"{type(exc).__name__}: {exc}",
+                                "rollback": "not guaranteed; restart required",
+                            }
+                        )
+        finally:
+            call_post_reload_hooks()
+
+    for item in published:
+        telemetry.event("published", **item)
+    for item in rejected:
+        telemetry.event("rejected", **item)
+    _dump_status()
+    return {"installed": True, "deferred": False, "published": published, "rejected": rejected}
+
+
+def state() -> dict[str, Any]:
+    with _STATE_LOCK:
+        pending = list(_PENDING.values())
+    return {
+        "installed": _INSTALLED,
+        "pending": pending,
+        "manifest": _MANIFEST,
+        "telemetry": telemetry.snapshot(),
+    }
+
+
+def _dump_status() -> None:
+    root = os.getenv("HMR_VLLM_STATUS_DIR")
+    if root:
+        target = Path(root) / f"{os.getpid()}.json"
+        temp = target.with_suffix(".tmp")
+        temp.write_text(json.dumps(state(), sort_keys=True), encoding="utf-8")
+        temp.replace(target)

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
@@ -124,7 +124,7 @@ def _watch() -> None:
                     }
                     telemetry.event("source_change", path=rel, decision=decision.as_dict())
             _dump_status()
-    except Exception as exc:  # noqa: BLE001 - watcher failures must be receipted
+    except Exception as exc:
         telemetry.event("watcher_failed", error=f"{type(exc).__name__}: {exc}")
         _dump_status()
 
@@ -136,7 +136,7 @@ def _load_handle(module):
     helper = getattr(core, "_hmr_probe_load", None)
     if helper is None:
         namespace = core.__dict__
-        exec("def _hmr_probe_load(module):\n    return module.load\n", namespace)  # noqa: S102 - construct a helper inside HMR's protected package
+        exec("def _hmr_probe_load(module):\n    return module.load\n", namespace)
         helper = namespace["_hmr_probe_load"]
     return helper(module)
 
@@ -217,7 +217,7 @@ def sync_pending(*, force: bool = False) -> dict[str, Any]:
                                 "forced_dependents_reexecuted": forced_dependents_reexecuted,
                             }
                         )
-                    except Exception as exc:  # noqa: BLE001 - reject and receipt it
+                    except Exception as exc:
                         rejected.append(
                             {
                                 **record,

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/bootstrap.py
@@ -1,4 +1,5 @@
 """Ambient pyth-on-line finder, watcher, and request-boundary publisher."""
+
 # This disposable integration deliberately reports candidate errors verbatim.
 # ruff: noqa: TRY003, TRY301
 # pyright: reportMissingImports=false, reportArgumentType=false, reportIndexIssue=false
@@ -123,19 +124,19 @@ def _watch() -> None:
                     }
                     telemetry.event("source_change", path=rel, decision=decision.as_dict())
             _dump_status()
-    except BaseException as exc:
+    except Exception as exc:  # noqa: BLE001 - watcher failures must be receipted
         telemetry.event("watcher_failed", error=f"{type(exc).__name__}: {exc}")
         _dump_status()
 
 
 def _load_handle(module):
     """Access the intentionally private loader from a core-owned frame."""
-    import reactivity.hmr.core as core
+    from reactivity.hmr import core
 
     helper = getattr(core, "_hmr_probe_load", None)
     if helper is None:
         namespace = core.__dict__
-        exec("def _hmr_probe_load(module):\n    return module.load\n", namespace)
+        exec("def _hmr_probe_load(module):\n    return module.load\n", namespace)  # noqa: S102 - construct a helper inside HMR's protected package
         helper = namespace["_hmr_probe_load"]
     return helper(module)
 
@@ -216,7 +217,7 @@ def sync_pending(*, force: bool = False) -> dict[str, Any]:
                                 "forced_dependents_reexecuted": forced_dependents_reexecuted,
                             }
                         )
-                    except BaseException as exc:
+                    except Exception as exc:  # noqa: BLE001 - reject and receipt it
                         rejected.append(
                             {
                                 **record,

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/endpoint.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/endpoint.py
@@ -1,0 +1,34 @@
+"""Opt-in vLLM endpoint plugin for HMR state and publication evidence."""
+# pyright: reportMissingImports=false
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+
+from .bootstrap import state, sync_pending
+
+
+class HMRProbeEndpointPlugin:
+    name = "hmr_vllm_probe"
+    required_tasks = None
+
+    def attach_router(self, app: FastAPI) -> None:
+        @app.get("/__hmr__/state")
+        async def hmr_state(raw_request: Request):
+            engine = raw_request.app.state.hmr_probe_engine_client
+            workers = [] if engine is None else await engine.collective_rpc("hmr_probe_state")
+            return {"api": state(), "workers": workers}
+
+        @app.post("/__hmr__/sync")
+        async def hmr_sync(raw_request: Request, force: bool = False):
+            engine = raw_request.app.state.hmr_probe_engine_client
+            local = sync_pending(force=force)
+            workers = [] if engine is None else await engine.collective_rpc("hmr_probe_sync_pending", kwargs={"force": force})
+            return {"api": local, "workers": workers}
+
+    async def init_state(self, engine_client, state_obj, _args) -> None:
+        state_obj.hmr_probe_engine_client = engine_client
+
+
+def create_plugin():
+    return HMRProbeEndpointPlugin()

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/endpoint.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/endpoint.py
@@ -1,4 +1,5 @@
 """Opt-in vLLM endpoint plugin for HMR state and publication evidence."""
+
 # pyright: reportMissingImports=false
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/middleware.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/middleware.py
@@ -1,0 +1,40 @@
+"""Stable ASGI request boundary for controlled source publication."""
+
+from __future__ import annotations
+
+from . import telemetry
+from .bootstrap import sync_pending
+
+
+class HMRBoundaryMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        path = scope.get("path", "")
+        local_sync = {"installed": True, "skipped": "explicit sync endpoint"} if path == "/__hmr__/sync" else sync_pending()
+        app = scope.get("app")
+        engine = getattr(getattr(app, "state", None), "hmr_probe_engine_client", None)
+        worker_sync = None
+        if engine is not None and path.startswith("/v1/") and telemetry.active_scopes() == 0:
+            worker_sync = await engine.collective_rpc("hmr_probe_sync_pending")
+        telemetry.event("request_boundary", path=path, local_sync=local_sync, worker_sync=worker_sync)
+        telemetry.scope_enter(path)
+
+        async def send_with_marker(message):
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                marker = telemetry.latest_marker()
+                if marker:
+                    headers.append((b"x-hmr-probe-code-marker", marker.encode("ascii", "strict")))
+                headers.append((b"x-hmr-probe-api-pid", str(__import__("os").getpid()).encode()))
+                message["headers"] = headers
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_marker)
+        finally:
+            telemetry.scope_exit()

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/policy.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/policy.py
@@ -1,4 +1,5 @@
 """Fail-closed source-tree policy for the vLLM HMR experiment."""
+
 # ruff: noqa: PIE810
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/policy.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/policy.py
@@ -1,0 +1,70 @@
+"""Fail-closed source-tree policy for the vLLM HMR experiment."""
+# ruff: noqa: PIE810
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Decision:
+    stratum: str
+    action: str
+    reason: str
+
+    def as_dict(self):
+        return asdict(self)
+
+
+CENTRAL = {
+    "vllm/__init__.py",
+    "vllm/envs.py",
+    "vllm/config/__init__.py",
+    "vllm/logger.py",
+    "vllm/plugins/__init__.py",
+    "vllm/platforms/__init__.py",
+    "vllm/v1/engine/core.py",
+    "vllm/v1/engine/core_client.py",
+    "vllm/v1/worker/worker_base.py",
+}
+
+
+def classify(relative_path: str) -> Decision:
+    p = relative_path.replace("\\", "/")
+    suffix = Path(p).suffix
+    if p.startswith("tests/") or p.startswith("docs/") or p.startswith("examples/") or p.startswith("tools/"):
+        return Decision("test_or_docs", "no_live_effect", "outside the serving runtime")
+    if p in CENTRAL:
+        return Decision("central_hub", "restart_required", "global registries, process lifecycle, or cross-process protocol")
+    if p.startswith("csrc/") or suffix in {".cpp", ".cc", ".c", ".cu", ".cuh", ".so"}:
+        return Decision("native", "rebuild_and_worker_restart", "loaded native code cannot be transactionally overwritten")
+    if suffix != ".py":
+        if suffix in {".json", ".jinja", ".yaml", ".yml", ".toml"}:
+            return Decision("resource", "auto_only_if_tracked_read", "pyth-on-line tracks files only when opened in a reactive computation")
+        return Decision("non_runtime", "no_live_effect_or_restart", "not an automatically reloadable Python module")
+    if "/kernels/" in p or "/triton" in p or "triton_" in Path(p).name:
+        return Decision("kernel", "prepare_warm_switch", "new Triton object and specializations must be compiled and validated")
+    if p.startswith("vllm/model_executor/models/") or p.startswith("vllm/models/"):
+        return Decision("model_implementation", "restart_required", "loaded nn.Module instances retain old class and bound methods")
+    if "/core/sched/" in p or "scheduler" in Path(p).name:
+        return Decision("scheduler", "restart_required", "long-lived scheduler instances retain old class and mutable state")
+    if p.startswith("vllm/config/") or Path(p).name.endswith("config.py"):
+        return Decision("config", "restart_required", "live config objects are snapshots and schemas are process-wide")
+    if "/api_router.py" in p or p.startswith("vllm/entrypoints/"):
+        return Decision("route_or_entrypoint", "restart_or_stable_dispatch", "FastAPI captures route callables and app construction is one-shot")
+    return Decision("python_leaf_or_utility", "candidate_preflight", "eligible only after syntax/import validation and live dependency proof")
+
+
+def syntax_preflight(path: Path) -> tuple[bool, str | None]:
+    try:
+        ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return True, None
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/telemetry.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/telemetry.py
@@ -1,4 +1,5 @@
 """Stable, process-local telemetry for the disposable vLLM HMR probe."""
+
 # ruff: noqa: TRY003,ARG001
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/telemetry.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/telemetry.py
@@ -1,0 +1,117 @@
+"""Stable, process-local telemetry for the disposable vLLM HMR probe."""
+# ruff: noqa: TRY003,ARG001
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections import Counter, deque
+from pathlib import Path
+from types import FrameType
+from typing import Any
+
+_LOCK = threading.RLock()
+_STARTED = time.monotonic()
+_COUNTERS: Counter[str] = Counter()
+_MARKERS: dict[str, str] = {}
+_EVENTS: deque[dict[str, Any]] = deque(maxlen=500)
+_ACTIVE_SCOPES = 0
+
+
+def event(kind: str, **fields: Any) -> None:
+    with _LOCK:
+        _EVENTS.append({"t": time.monotonic(), "kind": kind, **fields})
+
+
+def hit(key: str, marker: str | None = None) -> None:
+    with _LOCK:
+        _COUNTERS[key] += 1
+        if marker:
+            _MARKERS[key] = marker
+
+
+def scope_enter(path: str) -> None:
+    global _ACTIVE_SCOPES
+    with _LOCK:
+        _ACTIVE_SCOPES += 1
+        _COUNTERS[f"http:{path}"] += 1
+
+
+def scope_exit() -> None:
+    global _ACTIVE_SCOPES
+    with _LOCK:
+        _ACTIVE_SCOPES -= 1
+        if _ACTIVE_SCOPES < 0:
+            raise AssertionError("negative active HMR scope count")
+
+
+def active_scopes() -> int:
+    with _LOCK:
+        return _ACTIVE_SCOPES
+
+
+def latest_marker(prefix: str = "HMR_PROBE_VLLM_") -> str | None:
+    with _LOCK:
+        values = [value for value in _MARKERS.values() if value.startswith(prefix)]
+        return values[-1] if values else None
+
+
+def _marker_from_code(frame: FrameType) -> str | None:
+    for value in frame.f_code.co_consts:
+        if isinstance(value, str) and value.startswith("HMR_PROBE_VLLM_"):
+            return value
+    return None
+
+
+def profile(frame: FrameType, profile_event: str, arg: object):
+    if profile_event != "call":
+        return profile
+    filename = frame.f_code.co_filename.replace("\\", "/")
+    name = frame.f_code.co_name
+    wanted = (
+        (filename.endswith("vllm/renderers/inputs/preprocess.py") and name in {"<module>", "extract_prompt_components"})
+        or (filename.endswith("vllm/v1/engine/async_llm.py") and name in {"<module>", "add_request"})
+        or (filename.endswith("vllm/entrypoints/openai/completion/api_router.py") and name in {"<module>", "create_completion"})
+        or (filename.endswith("vllm/envs.py") and name in {"<module>", "__getattr__"})
+        or (filename.endswith("vllm/model_executor/models/qwen2.py") and name in {"<module>", "forward", "_hmr_probe_model_helper"})
+    )
+    if wanted:
+        key = f"{Path(filename).as_posix()}:{name}"
+        hit(key, _marker_from_code(frame))
+    return profile
+
+
+def install_profiler() -> None:
+    import sys
+
+    if os.getenv("HMR_VLLM_PROFILE", "1") != "1":
+        return
+    sys.setprofile(profile)
+    threading.setprofile(profile)
+    event("profile_installed")
+
+
+def snapshot() -> dict[str, Any]:
+    with _LOCK:
+        return {
+            "pid": os.getpid(),
+            "ppid": os.getppid(),
+            "process_name": __import__("multiprocessing").current_process().name,
+            "uptime_s": time.monotonic() - _STARTED,
+            "active_scopes": _ACTIVE_SCOPES,
+            "counters": dict(_COUNTERS),
+            "markers": dict(_MARKERS),
+            "events": list(_EVENTS),
+            "source_root": os.getenv("HMR_VLLM_SOURCE_ROOT"),
+            "source_sha": os.getenv("HMR_VLLM_SOURCE_SHA"),
+        }
+
+
+def dump(path: str | Path) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp = target.with_suffix(".tmp")
+    temp.write_text(json.dumps(snapshot(), sort_keys=True), encoding="utf-8")
+    temp.replace(target)

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/worker.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/worker.py
@@ -1,4 +1,5 @@
 """Worker-side identity and publication RPCs for the CPU smoke."""
+
 # pyright: reportMissingImports=false, reportAttributeAccessIssue=false
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/hmr_vllm_probe/worker.py
+++ b/examples/vllm-cpu-hmr/hmr_vllm_probe/worker.py
@@ -1,0 +1,59 @@
+"""Worker-side identity and publication RPCs for the CPU smoke."""
+# pyright: reportMissingImports=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+class HMRWorkerExtension:
+    """Mixed into vLLM's CPU worker for two disposable RPCs."""
+
+    def hmr_probe_sync_pending(self, force: bool = False) -> dict[str, Any]:
+        from .bootstrap import sync_pending
+
+        return sync_pending(force=force)
+
+    def hmr_probe_state(self) -> dict[str, Any]:
+        import torch
+
+        from .bootstrap import state
+        from .telemetry import snapshot
+
+        model = self.get_model()
+        params = []
+        for index, (name, value) in enumerate(model.named_parameters()):
+            if index == 16:
+                break
+            params.append(
+                {
+                    "name": name,
+                    "data_ptr": value.data_ptr(),
+                    "shape": list(value.shape),
+                    "dtype": str(value.dtype),
+                }
+            )
+        if torch.cuda.is_available():
+            memory = {
+                "kind": "cuda",
+                "allocated": torch.cuda.memory_allocated(),
+                "reserved": torch.cuda.memory_reserved(),
+            }
+        else:
+            memory = {
+                "kind": "cpu",
+                "rss_bytes": __import__("psutil").Process().memory_info().rss,
+            }
+        return {
+            "pid": os.getpid(),
+            "rank": getattr(self, "rank", None),
+            "device": str(getattr(self, "device", None)),
+            "model_id": id(model),
+            "model_class_id": id(type(model)),
+            "model_class": f"{type(model).__module__}.{type(model).__qualname__}",
+            "parameter_sample": params,
+            "accelerator_memory": memory,
+            "hmr": state(),
+            "telemetry": snapshot(),
+        }

--- a/examples/vllm-cpu-hmr/mutations.py
+++ b/examples/vllm-cpu-hmr/mutations.py
@@ -1,4 +1,5 @@
 """Deterministic, byte-restoring source mutations for the CPU smoke."""
+
 # ruff: noqa: TRY003
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/mutations.py
+++ b/examples/vllm-cpu-hmr/mutations.py
@@ -1,0 +1,87 @@
+"""Deterministic, byte-restoring source mutations for the CPU smoke."""
+# ruff: noqa: TRY003
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SavedFile:
+    path: Path
+    existed: bool
+    content: bytes
+
+
+class MutationSet:
+    """Restore every edit byte-for-byte, including on assertion failure."""
+
+    def __init__(self, source_root: str | Path):
+        self.root = Path(source_root).resolve()
+        self.saved: dict[Path, SavedFile] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.restore()
+
+    def _save(self, relative: str) -> Path:
+        path = (self.root / relative).resolve()
+        if not path.is_relative_to(self.root):
+            raise ValueError(f"path escapes source root: {relative}")
+        if path not in self.saved:
+            self.saved[path] = SavedFile(path, path.exists(), path.read_bytes() if path.exists() else b"")
+        return path
+
+    def insert_statement(
+        self,
+        relative: str,
+        function: str,
+        statement: str,
+        *,
+        class_name: str | None = None,
+    ) -> int:
+        """Insert one physical source line as the function's first statement."""
+        path = self._save(relative)
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(path))
+        scope: ast.AST = tree
+        if class_name is not None:
+            classes = [node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name]
+            if len(classes) != 1:
+                raise AssertionError(f"expected one class {class_name!r} in {relative}, found {len(classes)}")
+            scope = classes[0]
+        candidates = scope.body if isinstance(scope, (ast.Module, ast.ClassDef)) else []
+        matches = [node for node in candidates if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function]
+        if len(matches) != 1:
+            raise AssertionError(f"expected one function {function!r} in {relative}, found {len(matches)}")
+        node = matches[0]
+        first = node.body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) and isinstance(first.value.value, str):
+            if first.end_lineno is None:
+                raise AssertionError("AST node has no end_lineno")
+            line = first.end_lineno + 1
+        else:
+            line = first.lineno
+        source_lines = text.splitlines(keepends=True)
+        indent = " " * (node.col_offset + 4)
+        source_lines.insert(line - 1, f"{indent}{statement}\n")
+        path.write_text("".join(source_lines), encoding="utf-8")
+        return line
+
+    def restore(self) -> None:
+        for saved in reversed(list(self.saved.values())):
+            if saved.existed:
+                saved.path.write_bytes(saved.content)
+            elif saved.path.exists():
+                saved.path.unlink()
+        self.saved.clear()
+
+
+def print_statement(marker: str) -> str:
+    if not marker.startswith("HMR_PROBE_VLLM_") or not marker.replace("_", "").isalnum():
+        raise ValueError("marker must be an alphanumeric HMR_PROBE_VLLM_ token")
+    return f'print("{marker}", "pid=" + str(__import__("os").getpid()), flush=True)'

--- a/examples/vllm-cpu-hmr/pyproject.toml
+++ b/examples/vllm-cpu-hmr/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "vllm-cpu-hmr-example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["watchfiles>=0.21,<2"]
+
+[project.entry-points."vllm.endpoint_plugins"]
+hmr_vllm_probe = "hmr_vllm_probe.endpoint:create_plugin"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["hmr_vllm_probe"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"sitecustomize.py" = "sitecustomize.py"

--- a/examples/vllm-cpu-hmr/run.sh
+++ b/examples/vllm-cpu-hmr/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${VLLM_HMR_IMAGE:-vllm-cpu-hmr-example:local}"
+BASE_IMAGE="vllm/vllm-openai-cpu:v0.28.0-x86_64"
+RESULTS="${VLLM_HMR_RESULTS:-$PWD/vllm-cpu-hmr-results}"
+NAME="vllm-cpu-hmr-$(date +%s)"
+
+if ! docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
+  echo "Missing $BASE_IMAGE. Pull it first with: docker pull $BASE_IMAGE" >&2
+  exit 1
+fi
+
+docker build --tag "$IMAGE" --file examples/vllm-cpu-hmr/Dockerfile .
+IMAGE_ID="$(docker image inspect "$BASE_IMAGE" --format '{{.Id}}')"
+IMAGE_DIGEST="$(docker image inspect "$BASE_IMAGE" --format '{{index .RepoDigests 0}}')"
+PYTH_CORE_SHA="$(docker run --rm --entrypoint python3 "$IMAGE" -c \
+  'import hashlib, reactivity.hmr.core as c; print(hashlib.sha256(open(c.__file__, "rb").read()).hexdigest())')"
+mkdir -p "$RESULTS"
+
+flock /tmp/hmr-engine-cpu.lock docker run --rm --name "$NAME" --shm-size=4g \
+  -v "$RESULTS:/results" \
+  "$IMAGE" \
+  --source /opt/vllm-release-source \
+  --results /results \
+  --model "${VLLM_HMR_MODEL:-facebook/opt-125m}" \
+  --port 18080 \
+  --image "$BASE_IMAGE" \
+  --image-id "$IMAGE_ID" \
+  --image-digest "$IMAGE_DIGEST" \
+  --vllm-version 0.28.0+cpu \
+  --installed-source /opt/venv/lib/python3.12/site-packages/vllm \
+  --pyth-core-path /opt/venv/lib/python3.12/site-packages/reactivity/hmr/core.py \
+  --pyth-core-sha256 "$PYTH_CORE_SHA"

--- a/examples/vllm-cpu-hmr/sitecustomize.py
+++ b/examples/vllm-cpu-hmr/sitecustomize.py
@@ -1,0 +1,19 @@
+"""Opt-in earliest-possible HMR injection for every spawned interpreter."""
+
+import os
+from pathlib import Path
+
+
+def _is_model_registry_inspector() -> bool:
+    """Do not leave a watchfiles thread in vLLM's short-lived probe process."""
+    try:
+        command = Path("/proc/self/cmdline").read_bytes()
+    except OSError:
+        return False
+    return b"vllm.model_executor.models.registry" in command
+
+
+if os.getenv("HMR_VLLM_ENABLE") == "1" and not _is_model_registry_inspector():
+    from hmr_vllm_probe.bootstrap import install_from_env
+
+    install_from_env()

--- a/examples/vllm-cpu-hmr/smoke.py
+++ b/examples/vllm-cpu-hmr/smoke.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """One-item real-vLLM CPU HMR smoke for the official CPU image."""
+
 # ruff: noqa: TRY003, TRY301
 # pyright: reportReturnType=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false, reportArgumentType=false, reportAttributeAccessIssue=false
 
@@ -60,7 +61,7 @@ def request_json(
         raw = exc.read()
         try:
             payload = json.loads(raw)
-        except Exception:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             payload = raw.decode(errors="replace")
         return (
             exc.code,
@@ -102,7 +103,7 @@ def wait_ready(base: str, process: subprocess.Popen, timeout: float) -> None:
             if status == 200:
                 return
             last = payload
-        except Exception as exc:
+        except (OSError, TimeoutError) as exc:
             last = repr(exc)
         time.sleep(1)
     raise TimeoutError(f"vLLM did not become ready: {last}")

--- a/examples/vllm-cpu-hmr/smoke.py
+++ b/examples/vllm-cpu-hmr/smoke.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""One-item real-vLLM CPU HMR smoke for the official CPU image."""
+# ruff: noqa: BLE001,TRY003,TRY301
+# pyright: reportReturnType=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false, reportArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from mutations import MutationSet, print_statement
+
+TARGET = "vllm/renderers/inputs/preprocess.py"
+FUNCTION = "extract_prompt_components"
+DEPENDENT = "vllm.v1.engine.async_llm"
+MARKER = "HMR_PROBE_VLLM_CPU_PRINT_D410F975_001"
+PYTH_SHA = "d410f975367e8a29b17183d108ef09a089e42b63"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def python_source_hashes(root: Path) -> dict[str, str]:
+    return {path.relative_to(root).as_posix(): sha256(path) for path in sorted((root / "vllm").rglob("*.py"))}
+
+
+def request_json(
+    base: str,
+    method: str,
+    path: str,
+    body: dict | None = None,
+    timeout: float = 300,
+):
+    data = None if body is None else json.dumps(body).encode()
+    request = urllib.request.Request(
+        base + path,
+        data=data,
+        method=method,
+        headers={"content-type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+            return (
+                response.status,
+                {key.lower(): value for key, value in response.headers.items()},
+                json.loads(raw) if raw else None,
+            )
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            payload = json.loads(raw)
+        except Exception:
+            payload = raw.decode(errors="replace")
+        return (
+            exc.code,
+            {key.lower(): value for key, value in exc.headers.items()},
+            payload,
+        )
+
+
+def completion(base: str, model: str):
+    return request_json(
+        base,
+        "POST",
+        "/v1/completions",
+        {
+            "model": model,
+            "prompt": "The next integer after 40 is",
+            "max_tokens": 4,
+            "temperature": 0,
+            "seed": 7,
+        },
+    )
+
+
+def state(base: str) -> dict[str, Any]:
+    status, _, payload = request_json(base, "GET", "/__hmr__/state")
+    if status != 200:
+        raise AssertionError(payload)
+    return payload
+
+
+def wait_ready(base: str, process: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last: object = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"vLLM exited during startup with {process.returncode}")
+        try:
+            status, _, payload = request_json(base, "GET", "/health", timeout=2)
+            if status == 200:
+                return
+            last = payload
+        except Exception as exc:
+            last = repr(exc)
+        time.sleep(1)
+    raise TimeoutError(f"vLLM did not become ready: {last}")
+
+
+def wait_manifest_pending(status_dir: Path, api_pid: int, timeout: float = 30) -> dict[str, Any]:
+    path = status_dir / f"{api_pid}.json"
+    deadline = time.monotonic() + timeout
+    last: object = None
+    while time.monotonic() < deadline:
+        try:
+            current = json.loads(path.read_text(encoding="utf-8"))
+            last = current
+            if any(item.get("path") == TARGET for item in current.get("pending", [])):
+                return current
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            last = repr(exc)
+        time.sleep(0.05)
+    raise TimeoutError(f"manifest watcher did not queue {TARGET}: {last}")
+
+
+def identity(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "api_pid": snapshot["api"]["telemetry"]["pid"],
+        "workers": [
+            {
+                "pid": worker["pid"],
+                "model_id": worker["model_id"],
+                "model_class_id": worker["model_class_id"],
+                "model_class": worker["model_class"],
+                "parameter_sample": worker["parameter_sample"],
+            }
+            for worker in snapshot["workers"]
+        ],
+    }
+
+
+def target_counter(snapshot: dict[str, Any], function: str) -> int:
+    counters = snapshot["api"]["telemetry"]["counters"]
+    return sum(value for key, value in counters.items() if key.endswith(f"preprocess.py:{function}"))
+
+
+def load_lines(text: str) -> list[str]:
+    needles = (
+        "starting to load model",
+        "loading model weights",
+        "loading weights",
+        "model loading took",
+    )
+    return [line for line in text.splitlines() if any(needle in line.lower() for needle in needles)]
+
+
+def publication_for_target(snapshot: dict[str, Any]) -> dict[str, Any] | None:
+    for event in reversed(snapshot["api"]["telemetry"]["events"]):
+        local_sync = event.get("local_sync")
+        if event.get("kind") != "request_boundary" or not isinstance(local_sync, dict):
+            continue
+        for published in local_sync.get("published", []):
+            if published.get("path") == TARGET:
+                return published
+    return None
+
+
+def run(args: argparse.Namespace) -> None:
+    source = Path(args.source).resolve()
+    results = Path(args.results).resolve()
+    results.mkdir(parents=True, exist_ok=True)
+    log_path = results / "cpu-smoke-full.log"
+    receipt_path = results / "cpu-smoke-receipt.json"
+    status_dir = results / "process-state"
+    status_dir.mkdir(parents=True, exist_ok=True)
+    for stale in status_dir.glob("*.json"):
+        stale.unlink()
+
+    target = source / TARGET
+    if not target.is_file():
+        raise FileNotFoundError(f"release/source mismatch: runtime target absent: {target}")
+    original_target_hash = sha256(target)
+    baseline_hashes = python_source_hashes(source)
+    manifest = {
+        "schema_version": 1,
+        "source_root": str(source),
+        "reactive_paths": [
+            TARGET,
+            "vllm/v1/engine/async_llm.py",
+        ],
+        "files": [{"path": TARGET, "sha256": original_target_hash}],
+    }
+    manifest_path = results / "cpu-source-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HMR_VLLM_ENABLE": "1",
+            "HMR_VLLM_SOURCE_ROOT": str(source),
+            "HMR_VLLM_SOURCE_SHA": f"installed-vllm-{args.vllm_version}",
+            "HMR_VLLM_STATUS_DIR": str(status_dir),
+            "HMR_VLLM_MANIFEST": str(manifest_path),
+            "HMR_VLLM_AUTO_PATTERNS": TARGET,
+            "HMR_VLLM_LAZY_PATTERNS": "",
+            "HMR_VLLM_FORCED_DEPENDENTS": json.dumps({TARGET: [DEPENDENT]}),
+            # sys.setprofile adds a Python callback to every call and made the
+            # release-sized CPU import graph miss the 15 minute startup gate.
+            # The unique in-function print is the direct traversal evidence.
+            "HMR_VLLM_PROFILE": "0",
+            "VLLM_PLUGINS": "hmr_vllm_probe",
+            "VLLM_CPU_KVCACHE_SPACE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "PYTH_ON_LINE_SHA": PYTH_SHA,
+        }
+    )
+    command = [
+        "vllm",
+        "serve",
+        args.model,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(args.port),
+        "--dtype",
+        "float32",
+        "--max-model-len",
+        "64",
+        "--max-num-seqs",
+        "1",
+        "--enforce-eager",
+        "--distributed-executor-backend",
+        "uni",
+        "--worker-extension-cls",
+        "hmr_vllm_probe.worker.HMRWorkerExtension",
+        "--middleware",
+        "hmr_vllm_probe.middleware.HMRBoundaryMiddleware",
+    ]
+    process: subprocess.Popen | None = None
+    receipt: dict[str, Any] = {
+        "schema_version": 1,
+        "status": "failed",
+        "started_at": time.time(),
+        "official_image": args.image,
+        "official_image_id": args.image_id,
+        "official_image_digest": args.image_digest,
+        "vllm_distribution_version": args.vllm_version,
+        "installed_distribution_source": args.installed_source,
+        "runtime_source_root": str(source),
+        "runtime_source_resolution": (
+            "The official v0.28.0+cpu wheel lives under site-packages, which "
+            "pyth-on-line d410f975 excludes by design. The container copies that "
+            "installed vllm package byte-for-byte to an external runtime source "
+            "root and imports the copy first; no upstream 9dd source is used."
+        ),
+        "reactive_scope": (
+            "Only the manifest-listed provider and its actual direct from-import consumer are reactive. This proves this one request-path Python function/dependency chain, not arbitrary vLLM modules."
+        ),
+        "pyth_on_line_sha": PYTH_SHA,
+        "pyth_core_path": args.pyth_core_path,
+        "pyth_core_sha256": args.pyth_core_sha256,
+        "target": {
+            "path": TARGET,
+            "function": FUNCTION,
+            "original_sha256": original_target_hash,
+        },
+        "marker": MARKER,
+        "model": args.model,
+        "command": command,
+        "manifest_path": str(manifest_path),
+        "log_path": str(log_path),
+        "receipt_path": str(receipt_path),
+        "assertions": {},
+    }
+    try:
+        with log_path.open("w", encoding="utf-8") as output:
+            process = subprocess.Popen(
+                command,
+                cwd=source,
+                env=env,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+                text=True,
+                start_new_session=True,
+            )
+        base = f"http://127.0.0.1:{args.port}"
+        wait_ready(base, process, args.startup_timeout)
+
+        baseline_status, baseline_headers, baseline_payload = completion(base, args.model)
+        if baseline_status != 200:
+            raise AssertionError((baseline_status, baseline_payload))
+        before = state(base)
+        before_identity = identity(before)
+        if not before_identity["workers"]:
+            raise AssertionError("worker identity endpoint returned no workers")
+        if not before["api"]["installed"]:
+            raise AssertionError("early pyth-on-line injection is not installed in API process")
+        if before["api"].get("manifest") != manifest:
+            raise AssertionError("API process did not load the exact source manifest")
+        if any(not worker["hmr"]["installed"] or worker["hmr"].get("manifest") != manifest for worker in before["workers"]):
+            raise AssertionError("early injection/manifest was not active in every model worker")
+        before_log = log_path.read_text(encoding="utf-8", errors="replace")
+        load_evidence_before = load_lines(before_log)
+
+        with MutationSet(source) as edits:
+            inserted_line = edits.insert_statement(TARGET, FUNCTION, print_statement(MARKER))
+            mutated_hash = sha256(target)
+            if mutated_hash == original_target_hash:
+                raise AssertionError("target bytes did not change")
+            changed_while_mutated = sorted(key for key, digest in python_source_hashes(source).items() if baseline_hashes.get(key) != digest)
+            if changed_while_mutated != [TARGET]:
+                raise AssertionError(f"expected exactly one changed Python source, got {changed_while_mutated}")
+            mutated_text = target.read_text(encoding="utf-8")
+            statement = print_statement(MARKER)
+            if mutated_text.count(MARKER) != 1 or mutated_text.count(statement) != 1:
+                raise AssertionError("mutation did not insert exactly one unique print")
+
+            watcher_state = wait_manifest_pending(status_dir, before_identity["api_pid"])
+            post_status, post_headers, post_payload = completion(base, args.model)
+            if post_status != 200:
+                raise AssertionError((post_status, post_payload))
+            after = state(base)
+            after_identity = identity(after)
+            if after_identity != before_identity:
+                raise AssertionError((before_identity, after_identity))
+            publication = publication_for_target(after)
+            if publication is None:
+                raise AssertionError("next request boundary did not publish the manifest target")
+            if DEPENDENT not in publication.get("forced_dependents_reexecuted", []):
+                raise AssertionError(f"direct from-import dependent was not reexecuted: {publication}")
+            log_after = log_path.read_text(encoding="utf-8", errors="replace")
+            marker_line = f"{MARKER} pid={before_identity['api_pid']}"
+            if marker_line not in log_after:
+                raise AssertionError(f"marker missing from correct process log: {marker_line}")
+            post_edit_log = log_after[len(before_log) :]
+            load_evidence_after_edit = load_lines(post_edit_log)
+            if load_evidence_after_edit:
+                raise AssertionError(f"model reload evidence appeared after edit: {load_evidence_after_edit}")
+
+            receipt.update(
+                {
+                    "status": "passed",
+                    "baseline": {
+                        "http_status": baseline_status,
+                        "response_id": baseline_payload.get("id"),
+                        "choice_text": baseline_payload["choices"][0]["text"],
+                        "headers": baseline_headers,
+                    },
+                    "post_edit": {
+                        "http_status": post_status,
+                        "response_id": post_payload.get("id"),
+                        "choice_text": post_payload["choices"][0]["text"],
+                        "headers": post_headers,
+                    },
+                    "identity_before": before_identity,
+                    "identity_after": after_identity,
+                    "inserted_line": inserted_line,
+                    "mutated_sha256": mutated_hash,
+                    "changed_python_sources_while_mutated": changed_while_mutated,
+                    "watcher_pending_state": watcher_state,
+                    "publication": publication,
+                    "load_evidence_before_edit": load_evidence_before,
+                    "load_evidence_after_edit": load_evidence_after_edit,
+                    "marker_log_line": marker_line,
+                    "assertions": {
+                        "baseline_real_openai_inference_200": True,
+                        "early_injection_active_in_api_and_model_worker": True,
+                        "exactly_one_vllm_python_source_changed": True,
+                        "exactly_one_unique_print_inserted": True,
+                        "target_is_not_entrypoint": "entrypoint" not in TARGET,
+                        "manifest_watcher_queued_target_before_next_inference": True,
+                        "reactive_scope_exact_provider_and_direct_importer_only": True,
+                        "direct_importer_explicitly_invalidated_and_reexecuted": True,
+                        "next_real_openai_inference_200": True,
+                        "marker_in_api_process_log": True,
+                        "edited_function_traversed_by_unique_print": True,
+                        "same_api_and_worker_pids": True,
+                        "same_model_object_class_and_parameter_pointers": True,
+                        "no_model_reload_log_after_edit": True,
+                        "server_process_not_restarted": process.poll() is None,
+                    },
+                }
+            )
+        restored_hash = sha256(target)
+        restored_changes = sorted(key for key, digest in python_source_hashes(source).items() if baseline_hashes.get(key) != digest)
+        receipt["target"]["restored_sha256"] = restored_hash
+        receipt["changed_python_sources_after_restore"] = restored_changes
+        receipt["assertions"]["edited_bytes_restored"] = restored_hash == original_target_hash and not restored_changes
+        if not receipt["assertions"]["edited_bytes_restored"]:
+            receipt["status"] = "failed"
+            raise AssertionError((original_target_hash, restored_hash, restored_changes))
+    except BaseException as exc:
+        receipt["status"] = "failed"
+        receipt["error"] = f"{type(exc).__name__}: {exc}"
+        raise
+    finally:
+        if process is not None and process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=30)
+        receipt["server_exit_code_after_teardown"] = None if process is None else process.returncode
+        receipt["server_stopped"] = process is None or process.poll() is not None
+        receipt["source_restored"] = sha256(target) == original_target_hash
+        receipt["finished_at"] = time.time()
+        receipt_path.write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    print(
+        json.dumps(
+            {
+                "status": receipt["status"],
+                "receipt_path": str(receipt_path),
+                "log_path": str(log_path),
+            }
+        )
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--results", required=True)
+    parser.add_argument("--model", default="facebook/opt-125m")
+    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument("--startup-timeout", type=float, default=900)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--image-id", required=True)
+    parser.add_argument("--image-digest", required=True)
+    parser.add_argument("--vllm-version", required=True)
+    parser.add_argument("--installed-source", required=True)
+    parser.add_argument("--pyth-core-path", required=True)
+    parser.add_argument("--pyth-core-sha256", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/examples/vllm-cpu-hmr/smoke.py
+++ b/examples/vllm-cpu-hmr/smoke.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """One-item real-vLLM CPU HMR smoke for the official CPU image."""
-# ruff: noqa: BLE001,TRY003,TRY301
+# ruff: noqa: TRY003, TRY301
 # pyright: reportReturnType=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false, reportArgumentType=false, reportAttributeAccessIssue=false
 
 from __future__ import annotations

--- a/examples/vllm-cpu-hmr/tests/test_smoke_helpers.py
+++ b/examples/vllm-cpu-hmr/tests/test_smoke_helpers.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+EXAMPLE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_ROOT))
+from mutations import MutationSet, print_statement
+
+spec = importlib.util.spec_from_file_location("vllm_cpu_hmr_smoke", EXAMPLE_ROOT / "smoke.py")
+assert spec and spec.loader
+smoke = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(smoke)
+
+
+class SmokeHelperTests(unittest.TestCase):
+    def test_only_target_source_changes_and_is_restored(self):
+        root = Path(tempfile.mkdtemp())
+        try:
+            package = root / "vllm"
+            package.mkdir()
+            target = package / "target.py"
+            other = package / "other.py"
+            original_target = b"def target(x):\n    return x\n"
+            target.write_bytes(original_target)
+            other.write_text("VALUE = 2\n")
+            before = smoke.python_source_hashes(root)
+            marker = "HMR_PROBE_VLLM_TEST_001"
+            with MutationSet(root) as edits:
+                line = edits.insert_statement("vllm/target.py", "target", print_statement(marker))
+                self.assertEqual(line, 2)
+                ast.parse(target.read_text())
+                self.assertEqual(
+                    [path for path, digest in smoke.python_source_hashes(root).items() if before[path] != digest],
+                    ["vllm/target.py"],
+                )
+            self.assertEqual(target.read_bytes(), original_target)
+            self.assertEqual(smoke.python_source_hashes(root), before)
+        finally:
+            shutil.rmtree(root)
+
+    def test_publication_requires_forced_direct_importer(self):
+        published = {
+            "path": smoke.TARGET,
+            "forced_dependents_reexecuted": [smoke.DEPENDENT],
+        }
+        snapshot = {
+            "api": {
+                "telemetry": {
+                    "events": [
+                        {
+                            "kind": "request_boundary",
+                            "local_sync": {"published": [published]},
+                        }
+                    ]
+                }
+            }
+        }
+        self.assertEqual(smoke.publication_for_target(snapshot), published)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/hmr/README.md
+++ b/packages/hmr/README.md
@@ -32,3 +32,7 @@ If you are running your entry file with `python foo.py bar baz ...`, you can jus
 You can also run modules with `hmr -m <module>`, just like `python -m <module>`.
 
 Try it with `uvx` or `pipx`. If you are using a virtual environment, it is recommended to install `hmr` in the virtual environment instead of globally.
+
+## Integration example
+
+For a real CPU inference-server smoke, see [`examples/vllm-cpu-hmr`](../../examples/vllm-cpu-hmr/). It runs one OpenAI-compatible vLLM request before and after a Python source edit, then records PID, model-identity, and byte-restoration evidence.


### PR DESCRIPTION
## Summary
- add a disposable, manifest-scoped vLLM CPU HMR example under `examples/vllm-cpu-hmr`
- run the official `vllm/vllm-openai-cpu:v0.28.0-x86_64` image with pyth-on-line HMR injected before vLLM imports
- record real OpenAI API, PID/model identity, no-reload, marker, and byte-restoration evidence
- link the example from the HMR package README

## Why
The official CPU image ships vLLM as a site-packages wheel while HMR intentionally excludes virtualenv/site-packages paths. The example resolves this explicitly by copying the installed package to an external source root and recording the source layout. It scopes reactive imports to the edited provider and its direct importer, and uses a manifest watcher for the edited source.

## Verification
- `ruff check examples/vllm-cpu-hmr`
- `ruff format --check examples/vllm-cpu-hmr`
- `basedpyright examples/vllm-cpu-hmr`
- `pytest -q examples/vllm-cpu-hmr/tests` (2 passed)
- `PYTHONPATH=examples/vllm-cpu-hmr python3 -m unittest discover -s examples/vllm-cpu-hmr/tests -v` (2 passed)
- real `./examples/vllm-cpu-hmr/run.sh` smoke in the official CPU image (passed)

## Scope
This is an example/validation boundary for one CPU/Python request path and one worker. It does not claim arbitrary vLLM source, model-class replacement, weights reload, Triton/CUDA, torch.compile, CUDA Graph, or multi-rank safety. Generated logs and receipts are not committed.